### PR TITLE
[WIP] POC: Introducing total/activity generic metric API endpoints

### DIFF
--- a/apps/api/src/activity/activity.controller.ts
+++ b/apps/api/src/activity/activity.controller.ts
@@ -1,0 +1,159 @@
+import {
+  ApiBadRequestResponse,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+
+import {
+  ContractContext,
+  MetricResponse,
+  MetricQuery,
+  LeaderboardMetricResponse,
+  TotalMetric,
+  DaoStatsMetric,
+  DaoContractContext,
+} from '@dao-stats/common';
+import { ActivityInterval } from '@dao-stats/common/types/activity-interval';
+
+import { ContractContextPipe, MetricQueryPipe } from '../pipes';
+import { ActivityApiMetricService } from './interfaces/activity-api-metric.interface';
+import { ActivityApiMetricPipe } from './pipes/activity-api-metric.pipe';
+import { ActivityApiMetric } from './types/activity-api-metric';
+
+@ApiTags('Activity')
+@Controller('activity')
+export class ActivityController {
+  @ApiResponse({
+    status: 200,
+    type: TotalMetric,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Activity Metric: e.g ${ActivityApiMetric.DaoActivity}`,
+    enum: ActivityApiMetric,
+  })
+  @ApiQuery({
+    name: 'interval',
+    description: `Activity Interval: e.g ${ActivityInterval.Week}`,
+    enum: ActivityInterval,
+  })
+  @Get('/:metric')
+  async totals(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Param('metric', ActivityApiMetricPipe)
+    service: ActivityApiMetricService<ActivityApiMetric>,
+    @Query('interval') interval: ActivityInterval,
+  ): Promise<TotalMetric> {
+    return service.getActivity(context, interval);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: MetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${DaoStatsMetric.DaoCount}`,
+    enum: ActivityApiMetric,
+  })
+  @ApiQuery({
+    name: 'interval',
+    description: `Activity Interval: e.g ${ActivityInterval.Week}`,
+    enum: ActivityInterval,
+  })
+  @Get('/:metric/history')
+  async history(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Param('metric', ActivityApiMetricPipe)
+    service: ActivityApiMetricService<ActivityApiMetric>,
+    @Query(MetricQueryPipe) metricQuery: MetricQuery,
+    @Query('interval') interval: ActivityInterval,
+  ): Promise<MetricResponse> {
+    return service.getHistory(context, metricQuery, interval);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: LeaderboardMetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${DaoStatsMetric.DaoCount}`,
+    enum: ActivityApiMetric,
+  })
+  @Get('/:metric/leaderboard')
+  async leaderboard(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Param('metric', ActivityApiMetricPipe)
+    service: ActivityApiMetricService<ActivityApiMetric>,
+  ): Promise<LeaderboardMetricResponse> {
+    return service.getLeaderboard(context);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: TotalMetric,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Activity Metric: e.g ${ActivityApiMetric.DaoActivity}`,
+    enum: ActivityApiMetric,
+  })
+  @ApiQuery({
+    name: 'interval',
+    description: `Activity Interval: e.g ${ActivityInterval.Week}`,
+    enum: ActivityInterval,
+  })
+  @Get('/:metric/:dao')
+  async daoTotals(
+    @Param(ContractContextPipe) context: DaoContractContext,
+    @Param('metric', ActivityApiMetricPipe)
+    service: ActivityApiMetricService<ActivityApiMetric>,
+    @Query('interval') interval: ActivityInterval,
+  ): Promise<TotalMetric> {
+    return service.getActivity(context, interval);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: MetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Activity Metric: e.g ${ActivityApiMetric.DaoActivity}`,
+    enum: ActivityApiMetric,
+  })
+  @ApiQuery({
+    name: 'interval',
+    description: `Activity Interval: e.g ${ActivityInterval.Week}`,
+    enum: ActivityInterval,
+  })
+  @Get('/:metric/:dao/history')
+  async daoHistory(
+    @Param(ContractContextPipe) context: DaoContractContext,
+    @Param('metric', ActivityApiMetricPipe)
+    service: ActivityApiMetricService<ActivityApiMetric>,
+    @Query(MetricQueryPipe) metricQuery: MetricQuery,
+    @Query('interval') interval: ActivityInterval,
+  ): Promise<MetricResponse> {
+    return service.getHistory(context, metricQuery, interval);
+  }
+}

--- a/apps/api/src/activity/activity.module.ts
+++ b/apps/api/src/activity/activity.module.ts
@@ -1,0 +1,21 @@
+import { CacheModule, Module } from '@nestjs/common';
+
+import { CacheConfigService } from '@dao-stats/config/cache';
+import { ContractModule } from '@dao-stats/common';
+import { TransactionModule } from '@dao-stats/transaction';
+
+import { ActivityController } from './activity.controller';
+import metrics from './metrics';
+
+@Module({
+  imports: [
+    CacheModule.registerAsync({
+      useClass: CacheConfigService,
+    }),
+    TransactionModule,
+    ContractModule,
+  ],
+  providers: [...metrics],
+  controllers: [ActivityController],
+})
+export class ActivityModule {}

--- a/apps/api/src/activity/interfaces/activity-api-metric.interface.ts
+++ b/apps/api/src/activity/interfaces/activity-api-metric.interface.ts
@@ -1,0 +1,29 @@
+import {
+  ContractContext,
+  LeaderboardMetricResponse,
+  MetricQuery,
+  MetricResponse,
+  TotalMetric,
+} from '@dao-stats/common';
+import { ActivityInterval } from '@dao-stats/common/types/activity-interval';
+
+import { ApiMetricService } from '../../common/interfaces/api-metric.interface';
+import { ActivityApiMetric } from '../types/activity-api-metric';
+
+export interface ActivityApiMetricService<T extends ActivityApiMetric>
+  extends ApiMetricService<T> {
+  getType(): T;
+
+  getActivity(
+    context: ContractContext,
+    interval: ActivityInterval,
+  ): Promise<TotalMetric>;
+
+  getHistory(
+    context: ContractContext,
+    metricQuery: MetricQuery,
+    interval?: string,
+  ): Promise<MetricResponse>;
+
+  getLeaderboard(context: ContractContext): Promise<LeaderboardMetricResponse>;
+}

--- a/apps/api/src/activity/metrics/dao-activity.metric.ts
+++ b/apps/api/src/activity/metrics/dao-activity.metric.ts
@@ -1,0 +1,127 @@
+import { Injectable } from '@nestjs/common';
+import moment from 'moment';
+
+import {
+  ContractContext,
+  LeaderboardMetricResponse,
+  MetricQuery,
+  MetricResponse,
+  TotalMetric,
+} from '@dao-stats/common';
+import { TransactionService } from '@dao-stats/transaction';
+import { ActivityInterval } from '@dao-stats/common/types/activity-interval';
+
+import { ActivityApiMetricService } from '../interfaces/activity-api-metric.interface';
+import { getDailyIntervals, getGrowth } from '../../utils';
+import { ActivityApiMetric } from '../types/activity-api-metric';
+
+@Injectable()
+export class DaoActivityApiMetricService
+  implements ActivityApiMetricService<ActivityApiMetric>
+{
+  constructor(private readonly transactionService: TransactionService) {}
+
+  getType(): ActivityApiMetric.DaoActivity {
+    return ActivityApiMetric.DaoActivity;
+  }
+
+  async getActivity(
+    context: ContractContext,
+    interval: ActivityInterval,
+  ): Promise<TotalMetric> {
+    const intervalAgo = moment().subtract(1, interval);
+    const growthIntervalAgo = moment().subtract(2, interval);
+
+    const [activity, monthAgoActivity] = await Promise.all([
+      this.transactionService.getContractActivityCount(context, {
+        from: intervalAgo.valueOf(),
+      }),
+      this.transactionService.getContractActivityCount(context, {
+        from: growthIntervalAgo.valueOf(),
+        to: intervalAgo.valueOf(),
+      }),
+    ]);
+
+    return {
+      count: activity.count,
+      growth: getGrowth(activity.count, monthAgoActivity.count),
+    };
+  }
+
+  async getHistory(
+    context: ContractContext,
+    metricQuery: MetricQuery,
+    interval?: ActivityInterval,
+  ): Promise<MetricResponse> {
+    const metrics =
+      await this.transactionService.getContractActivityCountHistory(
+        context,
+        metricQuery,
+        interval,
+      );
+
+    return {
+      metrics: metrics.map(({ day, count }) => ({
+        timestamp: moment(day).valueOf(),
+        count,
+      })),
+    };
+  }
+
+  async getLeaderboard(
+    context: ContractContext,
+  ): Promise<LeaderboardMetricResponse> {
+    const monthAgo = moment().subtract(1, 'month');
+    const days = getDailyIntervals(monthAgo.valueOf(), moment().valueOf());
+
+    const byDays = await this.transactionService.getActivityLeaderboard(
+      context,
+      {
+        from: monthAgo.valueOf(),
+        to: moment().valueOf(),
+      },
+      true,
+    );
+
+    const dayAgo = moment().subtract(1, 'days');
+    const dayAgoActivity = await this.transactionService.getActivityLeaderboard(
+      context,
+      {
+        to: dayAgo.valueOf(),
+      },
+    );
+
+    const totalActivity = await this.transactionService.getActivityLeaderboard(
+      context,
+      {
+        to: moment().valueOf(),
+      },
+    );
+
+    const metrics = totalActivity.map(({ receiver_account_id: dao, count }) => {
+      const dayAgoCount =
+        dayAgoActivity.find(
+          ({ receiver_account_id }) => receiver_account_id === dao,
+        )?.count || 0;
+
+      return {
+        dao,
+        activity: {
+          count,
+          growth: getGrowth(count, dayAgoCount),
+        },
+        overview: days.map(({ end: timestamp }) => ({
+          timestamp,
+          count:
+            byDays.find(
+              ({ receiver_account_id, day }) =>
+                receiver_account_id === dao &&
+                moment(day).isSame(moment(timestamp), 'day'),
+            )?.count || 0,
+        })),
+      };
+    });
+
+    return { metrics };
+  }
+}

--- a/apps/api/src/activity/metrics/index.ts
+++ b/apps/api/src/activity/metrics/index.ts
@@ -1,0 +1,4 @@
+import { DaoActivityApiMetricService } from './dao-activity.metric';
+import { UserActivityApiMetricService } from './user-activity.metric';
+
+export default [DaoActivityApiMetricService, UserActivityApiMetricService];

--- a/apps/api/src/activity/metrics/user-activity.metric.ts
+++ b/apps/api/src/activity/metrics/user-activity.metric.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import moment from 'moment';
+
+import {
+  ContractContext,
+  LeaderboardMetricResponse,
+  MetricQuery,
+  MetricResponse,
+  TotalMetric,
+} from '@dao-stats/common';
+import { TransactionService } from '@dao-stats/transaction';
+import { ActivityInterval } from '@dao-stats/common/types/activity-interval';
+
+import { ActivityApiMetricService } from '../interfaces/activity-api-metric.interface';
+import { getDailyIntervals, getGrowth } from '../../utils';
+import { ActivityApiMetric } from '../types/activity-api-metric';
+
+@Injectable()
+export class UserActivityApiMetricService
+  implements ActivityApiMetricService<ActivityApiMetric>
+{
+  constructor(private readonly transactionService: TransactionService) {}
+
+  getType(): ActivityApiMetric.UserActivity {
+    return ActivityApiMetric.UserActivity;
+  }
+
+  async getActivity(
+    context: ContractContext,
+    interval: ActivityInterval,
+  ): Promise<TotalMetric> {
+    const intervalAgo = moment().subtract(1, interval);
+    const growthIntervalAgo = moment().subtract(2, interval);
+
+    const [activity, monthAgoActivity] = await Promise.all([
+      this.transactionService.getUsersTotalCount(context, {
+        from: intervalAgo.valueOf(),
+      }),
+      this.transactionService.getUsersTotalCount(context, {
+        from: growthIntervalAgo.valueOf(),
+        to: intervalAgo.valueOf(),
+      }),
+    ]);
+
+    return {
+      count: activity.count,
+      growth: getGrowth(activity.count, monthAgoActivity.count),
+    };
+  }
+
+  async getHistory(
+    context: ContractContext,
+    metricQuery: MetricQuery,
+    interval?: ActivityInterval,
+  ): Promise<MetricResponse> {
+    const metrics = await this.transactionService.getUsersTotalCountHistory(
+      context,
+      metricQuery,
+      interval,
+    );
+
+    return {
+      metrics: metrics.map(({ day, count }) => ({
+        timestamp: moment(day).valueOf(),
+        count,
+      })),
+    };
+  }
+
+  async getLeaderboard(
+    context: ContractContext,
+  ): Promise<LeaderboardMetricResponse> {
+    const monthAgo = moment().subtract(1, 'month');
+    const days = getDailyIntervals(monthAgo.valueOf(), moment().valueOf());
+
+    const byDays = await this.transactionService.getActivityLeaderboard(
+      context,
+      {
+        from: monthAgo.valueOf(),
+        to: moment().valueOf(),
+      },
+      true,
+    );
+
+    const dayAgo = moment().subtract(1, 'days');
+    const dayAgoActivity = await this.transactionService.getActivityLeaderboard(
+      context,
+      {
+        to: dayAgo.valueOf(),
+      },
+    );
+
+    const totalActivity = await this.transactionService.getActivityLeaderboard(
+      context,
+      {
+        to: moment().valueOf(),
+      },
+    );
+
+    const metrics = totalActivity.map(({ receiver_account_id: dao, count }) => {
+      const dayAgoCount =
+        dayAgoActivity.find(
+          ({ receiver_account_id }) => receiver_account_id === dao,
+        )?.count || 0;
+
+      return {
+        dao,
+        activity: {
+          count,
+          growth: getGrowth(count, dayAgoCount),
+        },
+        overview: days.map(({ end: timestamp }) => ({
+          timestamp,
+          count:
+            byDays.find(
+              ({ receiver_account_id, day }) =>
+                receiver_account_id === dao &&
+                moment(day).isSame(moment(timestamp), 'day'),
+            )?.count || 0,
+        })),
+      };
+    });
+
+    return { metrics };
+  }
+}

--- a/apps/api/src/activity/pipes/activity-api-metric.pipe.ts
+++ b/apps/api/src/activity/pipes/activity-api-metric.pipe.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+import services from '../metrics';
+import { ApiMetricPipe } from '../../pipes/api-metric.pipe';
+
+@Injectable()
+export class ActivityApiMetricPipe extends ApiMetricPipe {
+  getServices() {
+    return services;
+  }
+}

--- a/apps/api/src/activity/types/activity-api-metric.ts
+++ b/apps/api/src/activity/types/activity-api-metric.ts
@@ -1,0 +1,4 @@
+export enum ActivityApiMetric {
+  DaoActivity = 'dao-activity',
+  UserActivity = 'user-activity',
+}

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -42,6 +42,8 @@ import { TvlModule } from './tvl/tvl.module';
 import { ApiDaoModule } from './dao/dao.module';
 import { TokensModule } from './tokens/tokens.module';
 import { MarketModule } from './market/market.module';
+import { TotalsModule } from './totals/totals.module';
+import { ActivityModule } from './activity/activity.module';
 
 @Module({
   imports: [
@@ -75,6 +77,8 @@ import { MarketModule } from './market/market.module';
     TvlModule,
     TokensModule,
     MarketModule,
+    TotalsModule,
+    ActivityModule,
   ],
   providers: [
     {

--- a/apps/api/src/common/interfaces/api-metric.interface.ts
+++ b/apps/api/src/common/interfaces/api-metric.interface.ts
@@ -1,0 +1,5 @@
+import { ApiMetric } from '../types/api-metric';
+
+export interface ApiMetricService<T extends ApiMetric> {
+  getType(): T;
+}

--- a/apps/api/src/common/types/api-metric.ts
+++ b/apps/api/src/common/types/api-metric.ts
@@ -1,0 +1,4 @@
+import { ActivityApiMetric } from '../../activity/types/activity-api-metric';
+import { TotalApiMetric } from '../../totals/types/total-metric-type';
+
+export type ApiMetric = TotalApiMetric | ActivityApiMetric;

--- a/apps/api/src/general/general.service.ts
+++ b/apps/api/src/general/general.service.ts
@@ -13,6 +13,7 @@ import { TransactionService } from '@dao-stats/transaction';
 import { GeneralTotalResponse } from './dto';
 import { MetricService } from '../common/metric.service';
 import { getDailyIntervals, getGrowth } from '../utils';
+import { ActivityInterval } from '@dao-stats/common/types/activity-interval';
 
 @Injectable()
 export class GeneralService {
@@ -68,9 +69,10 @@ export class GeneralService {
     metricQuery: MetricQuery,
   ): Promise<MetricResponse> {
     const metrics =
-      await this.transactionService.getContractActivityCountWeekly(
+      await this.transactionService.getContractActivityCountHistory(
         context,
         metricQuery,
+        ActivityInterval.Week,
       );
 
     return {

--- a/apps/api/src/pipes/api-metric.pipe.ts
+++ b/apps/api/src/pipes/api-metric.pipe.ts
@@ -1,0 +1,36 @@
+import { ModuleRef } from '@nestjs/core';
+import {
+  ArgumentMetadata,
+  Injectable,
+  NotFoundException,
+  PipeTransform,
+} from '@nestjs/common';
+
+import { ApiMetricService } from '../common/interfaces/api-metric.interface';
+import { ApiMetric } from '../common/types/api-metric';
+
+@Injectable()
+export abstract class ApiMetricPipe implements PipeTransform {
+  constructor(private readonly moduleRef: ModuleRef) {}
+
+  abstract getServices(): any[];
+
+  async transform(metric: ApiMetric, metadata: ArgumentMetadata) {
+    let service: ApiMetricService<ApiMetric>;
+    for (const serviceClass of this.getServices()) {
+      const instance = this.moduleRef.get(serviceClass);
+
+      if (instance.getType() === metric) {
+        service = instance;
+
+        break;
+      }
+    }
+
+    if (!service) {
+      throw new NotFoundException('Metric not found!');
+    }
+
+    return service;
+  }
+}

--- a/apps/api/src/pipes/metric-query.pipe.ts
+++ b/apps/api/src/pipes/metric-query.pipe.ts
@@ -21,6 +21,7 @@ export class MetricQueryPipe implements PipeTransform {
     const { contractId }: ContractContext = RequestContext.get();
 
     let { from, to } = query;
+    const { interval } = query;
 
     if (from) {
       from = moment(isNaN(from) ? from : parseInt(from));
@@ -41,6 +42,10 @@ export class MetricQueryPipe implements PipeTransform {
     to = moment(isNaN(to) ? to : parseInt(to));
     if (!to.isValid()) {
       throw new BadRequestException(`Invalid 'to' query parameter.`);
+    }
+
+    if (interval) {
+      to = to.subtract(1, interval).endOf(interval);
     }
 
     return {

--- a/apps/api/src/totals/interfaces/total-api-metric.interface.ts
+++ b/apps/api/src/totals/interfaces/total-api-metric.interface.ts
@@ -1,0 +1,24 @@
+import {
+  ContractContext,
+  LeaderboardMetricResponse,
+  MetricQuery,
+  MetricResponse,
+  TotalMetric,
+} from '@dao-stats/common';
+import { ApiMetricService } from '../../common/interfaces/api-metric.interface';
+import { TotalApiMetric } from '../types/total-metric-type';
+
+export interface TotalApiMetricService<T extends TotalApiMetric>
+  extends ApiMetricService<T> {
+  getType(): T;
+
+  getTotal(context: ContractContext): Promise<TotalMetric>;
+
+  getHistory(
+    context: ContractContext,
+    metricQuery: MetricQuery,
+    interval?: string,
+  ): Promise<MetricResponse>;
+
+  getLeaderboard(context: ContractContext): Promise<LeaderboardMetricResponse>;
+}

--- a/apps/api/src/totals/metrics/account-balance.metric.ts
+++ b/apps/api/src/totals/metrics/account-balance.metric.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ContractContext,
+  DaoStatsMetric,
+  LeaderboardMetricResponse,
+  MetricQuery,
+  MetricResponse,
+  TotalMetric,
+} from '@dao-stats/common';
+
+import { MetricService } from '../../common/metric.service';
+import { TotalApiMetric } from '../types/total-metric-type';
+import { TotalApiMetricService } from '../interfaces/total-api-metric.interface';
+
+@Injectable()
+export class AccountBalanceApiMetricService
+  implements TotalApiMetricService<TotalApiMetric.AccountBalance>
+{
+  constructor(private readonly metricService: MetricService) {}
+
+  getType(): TotalApiMetric.AccountBalance {
+    return TotalApiMetric.AccountBalance;
+  }
+
+  getTotal(context: ContractContext): Promise<TotalMetric> {
+    return this.metricService.total(context, DaoStatsMetric.AccountBalance);
+  }
+
+  getHistory(
+    context: ContractContext,
+    metricQuery: MetricQuery,
+    interval?: string,
+  ): Promise<MetricResponse> {
+    return this.metricService.history(
+      context,
+      metricQuery,
+      DaoStatsMetric.AccountBalance,
+    );
+  }
+
+  getLeaderboard(context: ContractContext): Promise<LeaderboardMetricResponse> {
+    return this.metricService.leaderboard(
+      context,
+      DaoStatsMetric.AccountBalance,
+    );
+  }
+}

--- a/apps/api/src/totals/metrics/dao-count.metric.ts
+++ b/apps/api/src/totals/metrics/dao-count.metric.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  ContractContext,
+  DaoStatsMetric,
+  LeaderboardMetricResponse,
+  MetricQuery,
+  MetricResponse,
+  TotalMetric,
+} from '@dao-stats/common';
+
+import { MetricService } from '../../common/metric.service';
+import { TotalApiMetric } from '../types/total-metric-type';
+import { TotalApiMetricService } from '../interfaces/total-api-metric.interface';
+
+@Injectable()
+export class DaoCountApiMetricService
+  implements TotalApiMetricService<TotalApiMetric.DaoCount>
+{
+  constructor(private readonly metricService: MetricService) {}
+
+  getType(): TotalApiMetric.DaoCount {
+    return TotalApiMetric.DaoCount;
+  }
+
+  getTotal(context: ContractContext): Promise<TotalMetric> {
+    return this.metricService.total(context, DaoStatsMetric.DaoCount);
+  }
+
+  getHistory(
+    context: ContractContext,
+    metricQuery: MetricQuery,
+    interval?: string,
+  ): Promise<MetricResponse> {
+    return this.metricService.history(
+      context,
+      metricQuery,
+      DaoStatsMetric.DaoCount,
+    );
+  }
+
+  getLeaderboard(context: ContractContext): Promise<LeaderboardMetricResponse> {
+    return this.metricService.leaderboard(context, DaoStatsMetric.DaoCount);
+  }
+}

--- a/apps/api/src/totals/metrics/index.ts
+++ b/apps/api/src/totals/metrics/index.ts
@@ -1,0 +1,4 @@
+import { AccountBalanceApiMetricService } from './account-balance.metric';
+import { DaoCountApiMetricService } from './dao-count.metric';
+
+export default [AccountBalanceApiMetricService, DaoCountApiMetricService];

--- a/apps/api/src/totals/pipes/total-api-metric.pipe.ts
+++ b/apps/api/src/totals/pipes/total-api-metric.pipe.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+import services from '../metrics';
+import { ApiMetricPipe } from '../../pipes/api-metric.pipe';
+
+@Injectable()
+export class TotalApiMetricPipe extends ApiMetricPipe {
+  getServices() {
+    return services;
+  }
+}

--- a/apps/api/src/totals/totals.controller.ts
+++ b/apps/api/src/totals/totals.controller.ts
@@ -1,0 +1,132 @@
+import {
+  ApiBadRequestResponse,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+
+import {
+  ContractContext,
+  MetricResponse,
+  MetricQuery,
+  LeaderboardMetricResponse,
+  TotalMetric,
+  DaoContractContext,
+} from '@dao-stats/common';
+
+import { ContractContextPipe, MetricQueryPipe } from '../pipes';
+import { TotalApiMetricPipe } from './pipes/total-api-metric.pipe';
+import { TotalApiMetricService } from './interfaces/total-api-metric.interface';
+import { TotalApiMetric } from 'apps/api/src/totals/types/total-metric-type';
+
+@ApiTags('Totals')
+@Controller('totals')
+export class TotalsController {
+  @ApiResponse({
+    status: 200,
+    type: TotalMetric,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${TotalApiMetric.DaoCount}`,
+    enum: TotalApiMetric,
+  })
+  @Get('/:metric')
+  async totals(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Param('metric', TotalApiMetricPipe)
+    service: TotalApiMetricService<TotalApiMetric>,
+  ): Promise<TotalMetric> {
+    return service.getTotal(context);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: MetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${TotalApiMetric.DaoCount}`,
+    enum: TotalApiMetric,
+  })
+  @Get('/:metric/history')
+  async history(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Param('metric', TotalApiMetricPipe)
+    service: TotalApiMetricService<TotalApiMetric>,
+    @Query(MetricQueryPipe) metricQuery: MetricQuery,
+  ): Promise<MetricResponse> {
+    return service.getHistory(context, metricQuery);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: LeaderboardMetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${TotalApiMetric.DaoCount}`,
+    enum: TotalApiMetric,
+  })
+  @Get('/:metric/leaderboard')
+  async leaderboard(
+    @Param(ContractContextPipe) context: ContractContext,
+    @Param('metric', TotalApiMetricPipe)
+    service: TotalApiMetricService<TotalApiMetric>,
+  ): Promise<LeaderboardMetricResponse> {
+    return service.getLeaderboard(context);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: TotalMetric,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${TotalApiMetric.DaoCount}`,
+    enum: TotalApiMetric,
+  })
+  @Get('/:metric/:dao')
+  async daoTotals(
+    @Param(ContractContextPipe) context: DaoContractContext,
+    @Param('metric', TotalApiMetricPipe)
+    service: TotalApiMetricService<TotalApiMetric>,
+  ): Promise<TotalMetric> {
+    return service.getTotal(context);
+  }
+
+  @ApiResponse({
+    status: 200,
+    type: MetricResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Bad Request Response based on the query params set',
+  })
+  @ApiParam({
+    name: 'metric',
+    description: `Total Metric: e.g ${TotalApiMetric.DaoCount}`,
+    enum: TotalApiMetric,
+  })
+  @Get('/:metric/:dao/history')
+  async daoHistory(
+    @Param(ContractContextPipe) context: DaoContractContext,
+    @Param('metric', TotalApiMetricPipe)
+    service: TotalApiMetricService<TotalApiMetric>,
+    @Query(MetricQueryPipe) metricQuery: MetricQuery,
+  ): Promise<MetricResponse> {
+    return service.getHistory(context, metricQuery);
+  }
+}

--- a/apps/api/src/totals/totals.module.ts
+++ b/apps/api/src/totals/totals.module.ts
@@ -1,0 +1,23 @@
+import { CacheModule, Module } from '@nestjs/common';
+
+import { CacheConfigService } from '@dao-stats/config/cache';
+import { ContractModule } from '@dao-stats/common';
+import { TransactionModule } from '@dao-stats/transaction';
+
+import { TotalsController } from './totals.controller';
+import { MetricModule } from '../common/metric.module';
+import metrics from './metrics';
+
+@Module({
+  imports: [
+    CacheModule.registerAsync({
+      useClass: CacheConfigService,
+    }),
+    TransactionModule,
+    ContractModule,
+    MetricModule,
+  ],
+  providers: [...metrics],
+  controllers: [TotalsController],
+})
+export class TotalsModule {}

--- a/apps/api/src/totals/types/total-metric-type.ts
+++ b/apps/api/src/totals/types/total-metric-type.ts
@@ -1,0 +1,4 @@
+export enum TotalApiMetric {
+  DaoCount = 'dao-count',
+  AccountBalance = 'account-balance',
+}

--- a/libs/common/src/types/activity-interval.ts
+++ b/libs/common/src/types/activity-interval.ts
@@ -1,0 +1,5 @@
+export enum ActivityInterval {
+  Month = 'month',
+  Week = 'week',
+  Day = 'day',
+}

--- a/libs/transaction/src/transaction.service.ts
+++ b/libs/transaction/src/transaction.service.ts
@@ -13,6 +13,7 @@ import {
   TransactionType,
 } from '@dao-stats/common';
 import { TransactionLeaderboardDto } from './dto/transaction-leaderboard.dto';
+import { ActivityInterval } from '@dao-stats/common/types/activity-interval';
 
 @Injectable()
 export class TransactionService {
@@ -83,12 +84,13 @@ export class TransactionService {
     return this.getContractActivityCountQuery(context, metricQuery).getRawOne();
   }
 
-  async getContractActivityCountWeekly(
+  async getContractActivityCountHistory(
     context: DaoContractContext | ContractContext,
     metricQuery?: MetricQuery,
+    interval?: ActivityInterval,
   ): Promise<DailyCountDto[]> {
     let queryBuilder = this.getContractActivityCountQuery(context, metricQuery);
-    queryBuilder = this.addWeeklySelection(queryBuilder);
+    queryBuilder = this.addIntervalSelection(queryBuilder, interval);
 
     return queryBuilder.execute();
   }
@@ -98,6 +100,17 @@ export class TransactionService {
     metricQuery?: MetricQuery,
   ): Promise<Metric> {
     return this.getUsersTotalQueryBuilder(context, metricQuery).getRawOne();
+  }
+
+  async getUsersTotalCountHistory(
+    context: DaoContractContext | ContractContext,
+    metricQuery?: MetricQuery,
+    interval?: ActivityInterval,
+  ): Promise<DailyCountDto[]> {
+    let queryBuilder = this.getUsersTotalQueryBuilder(context, metricQuery);
+    queryBuilder = this.addIntervalSelection(queryBuilder, interval);
+
+    return queryBuilder.execute();
   }
 
   async getInteractionsCount(
@@ -250,12 +263,13 @@ export class TransactionService {
       .orderBy('day', 'ASC');
   }
 
-  private addWeeklySelection(
+  private addIntervalSelection(
     qb: SelectQueryBuilder<Transaction>,
+    interval: ActivityInterval,
   ): SelectQueryBuilder<Transaction> {
     return qb
       .addSelect(
-        `date_trunc('week', to_timestamp(block_timestamp / 1e9)) as day`,
+        `date_trunc('${interval}', to_timestamp(block_timestamp / 1e9) + '1 ${interval}'::interval) as day`,
       )
       .groupBy('day')
       .orderBy('day', 'ASC');


### PR DESCRIPTION
- added generic API endpoints:

`/totals/...` - responsible for handling all total, over-time total metrics

`/activity/...` - responsible for handling all activity metrics based on the interval provided.

Swagger example:
<img width="1527" alt="Screenshot 2022-01-25 at 14 24 20" src="https://user-images.githubusercontent.com/80328073/150976557-a3956eb8-906a-40d4-9521-bcea74058bbf.png">

List of the metrics supported by the endpoint is listed in the corresponding Swagger spec:
<img width="692" alt="Screenshot 2022-01-25 at 14 26 35" src="https://user-images.githubusercontent.com/80328073/150976928-68f73171-14a8-44ac-974c-5eb1f00f8da7.png">

TBD: `'/average'` endpoint following the same idea. 